### PR TITLE
Update for Catalina

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,9 @@ Requirements
 
 We support:
 
-* macOS Mavericks (10.9)
-* macOS Yosemite (10.10)
-* macOS El Capitan (10.11)
-* macOS Sierra (10.12)
 * macOS High Sierra (10.13)
 * macOS Mojave (10.14)
+* macOS Catalina (10.15)
 
 Older versions may work but aren't regularly tested.
 Bug reports for older versions are welcome.
@@ -25,33 +22,146 @@ Bug reports for older versions are welcome.
 Install
 -------
 
-Download the script:
+Open Terminal and Install xcode select:
 
-```sh
-curl --remote-name https://raw.githubusercontent.com/sprk/laptop/master/mac
+`xcode-select --install`
+
+Create you SSH key and link to your Github Account:
+
+`ssh-keygen -C your.name@spark.re`
+
+Enter a location to save the save the key. Press enter
+to save it in the default location, or enter a new location.
+If you save it in the default location, all ssh connections
+will use this key by default. You should only need to save
+it in a non default location if you use multiple keys.
+
+`# Enter file in which to save the key (/Users/USERNAME/.ssh/id_rsa):`
+
+Can also keep it simple and just press enter when prompted for the above.
+
+Be sure to add a password to your key to ensure the
+security of our servers. This won't need to be a password
+you remember, as the ssh agent can remember it for you
+(see below). So that being said, the best course of action
+is to use a generated password through Dashlane.
+
+Set your identity in the SSH Config:
+This will fix an issue when running deployments where
+you get permission denied from Github, since our local private
+keys are used by Capistranto when pulling the code.
+
+```
+touch ~/.ssh/config
+echo 'UseKeychain yes' >> ~/.ssh/config
+echo 'AddKeysToAgent yes' >> ~/.ssh/config
+echo 'IdentityFile ~/.ssh/id_rsa' >> ~/.ssh/config
+```
+
+Add the new SSH key to your terminal instance to prevent need to enter SSH password:
+
+`ssh-add -K`
+
+Link your SSH key with your Github Account. First, copy the
+SSH key to your clipboard.
+
+`cat ~/.ssh/id_rsa.pub | pbcopy`
+
+Github > Profile > Settings > SSH and GPG Keys > New SSH key.
+
+Download the computer setup repository to your root directory and move the mac script there too:
+
+```
+cd ~ && git clone git@github.com:sprk/laptop.git
+cp ~/laptop/mac ~/mac
 ```
 
 Review the script (avoid running scripts you haven't read!):
-
-```sh
+```
 less mac
 ```
 
 Execute the downloaded script:
-
-```sh
+```
 sh mac 2>&1 | tee ~/laptop.log
 ```
 
 Optionally, review the log:
-
-```sh
+```
 less ~/laptop.log
 ```
 
-Optionally, [install thoughtbot/dotfiles][dotfiles].
+Once Script Completes
+---------------------
 
-[dotfiles]: https://github.com/thoughtbot/dotfiles#install
+In iTerm2:
+Preferences > Profile > Command:
+Send text at start: `ssh-add -K`
+
+In Terminal, let GitHub know who you are:
+
+```
+git config --global user.name "Your Name"
+git config --global user.email your.name@spark.re
+```
+
+**Important:**
+Your computer has been through a lot since running this script.
+Restart it and move onto the next step.
+
+Setup Rbenv, Ruby and Spark
+---------------------------
+
+```
+rbenv install 2.6.5
+rbenv global 2.6.5
+```
+
+Relaunch your terminal.
+
+```
+gem install bundler
+gem install rails
+rbenv rehash
+
+cd ~/Sites
+git clone git@github.com:sprk/spark.git
+cd spark
+```
+
+Note: If you want Spark to be installed a directory other than 'sites', the following will need to be updated:
+```
+In itermocil/spark.yml - (code ~/.itermocil/spark.yml)
+windows:
+  - name: Spark
+    root: ~/Sites/spark
+```
+```
+In zshrc - (zshconfig)
+# FOLDER ALIASES
+alias si='cd ~/Sites/Spark'
+```
+
+Create the master key and copy the variable that has been shared with
+you in the Dashlane "Sharing Center" under "Rails - Credentials Master Key"
+`touch config/master.key && open config/master.key`
+
+Populate your private variables in the zshrc private file:
+`open ~/.files/zshrc/private`
+`SPARK_SEED_ADMIN_EMAIL="first.lastname@spark.re"`
+
+Unless you have received an aws access key id and secret key, leave these variables as is.
+
+Setup your local database and put your computers username in the designated field.
+`cp config/settings.local.example.yml config/settings.local.yml`
+`open config/settings.local.yml`
+
+Ensure yarn is setup correctly.
+`yarn install --check-files`
+
+Create and Populate your local database:
+`rboot`
+
 
 Debugging
 ---------
@@ -82,7 +192,6 @@ Unix tools:
 * [Tmux] for saving project state and switching between projects
 * [Watchman] for watching for filesystem events
 * [Zsh] as your shell
-* [Neovim] as the one true editor(tm) that you may choose to ignore
 
 [Exuberant Ctags]: http://ctags.sourceforge.net/
 [Git]: https://git-scm.com/
@@ -91,7 +200,6 @@ Unix tools:
 [The Silver Searcher]: https://github.com/ggreer/the_silver_searcher
 [Tmux]: http://tmux.github.io/
 [Watchman]: https://facebook.github.io/watchman/
-[Neovim]: https://neovim.io/
 [RipGrep]: https://github.com/BurntSushi/ripgrep
 [Zsh]: http://www.zsh.org/
 
@@ -126,65 +234,31 @@ Databases:
 [Postgres]: http://www.postgresql.org/
 [Redis]: http://redis.io/
 
+Programs:
+* [Brave Browser] Like Google Chrome but with built in privacy / ad-blockers.
+* [Dashlane] our password management tool.
+* [Firefox] always good to have a secondary browser. Plus nice dev tools.
+* [iTerm2] your standard terminal... upgraded.
+* [Postman] for Spark API queries.
+* [PSequel] for checking out your local database.
+* [Slack] office communications/chat channels.
+* [VSCode] only code editor a sane person will ever need.
+
+[Brave Browser]: https://brave.com/
+[Dashlane]: https://www.dashlane.com/
+[Firefox]: https://www.mozilla.org/en-CA/firefox/
+[iTerm2]: https://iterm2.com/
+[Postman]: https://www.getpostman.com/
+[PSequel]: http://www.psequel.com/
+[Slack]: https://slack.com/intl/en-ca/
+[VSCode]: https://code.visualstudio.com/
+
 It should take less than 15 minutes to install (depends on your machine).
-
-Customize in `~/.laptop.local`
-------------------------------
-
-Your `~/.laptop.local` is run at the end of the Laptop script.
-Put your customizations there.
-For example:
-
-```sh
-#!/bin/sh
-
-brew bundle --file=- <<EOF
-brew "Caskroom/cask/dockertoolbox"
-brew "go"
-brew "ngrok"
-brew "watch"
-EOF
-
-default_docker_machine() {
-  docker-machine ls | grep -Fq "default"
-}
-
-if ! default_docker_machine; then
-  docker-machine create --driver virtualbox default
-fi
-
-default_docker_machine_running() {
-  default_docker_machine | grep -Fq "Running"
-}
-
-if ! default_docker_machine_running; then
-  docker-machine start default
-fi
-
-fancy_echo "Cleaning up old Homebrew formulae ..."
-brew cleanup
-brew cask cleanup
-
-if [ -r "$HOME/.rcrc" ]; then
-  fancy_echo "Updating dotfiles ..."
-  rcup
-fi
-```
-
-Write your customizations such that they can be run safely more than once.
-See the `mac` script for examples.
-
-Laptop functions such as `fancy_echo` and
-`gem_install_or_update`
-can be used in your `~/.laptop.local`.
-
-See the [wiki](https://github.com/thoughtbot/laptop/wiki)
-for more customization examples.
 
 Contributing
 ------------
 
-Edit the `mac` file.
+Edit the `laptop` file.
 Document in the `README.md` file.
 Follow shell style guidelines by using [ShellCheck] and [Syntastic].
 
@@ -195,7 +269,7 @@ brew install shellcheck
 [ShellCheck]: http://www.shellcheck.net/about.html
 [Syntastic]: https://github.com/scrooloose/syntastic
 
-Thank you, !
+Thank you!
 
 Spark fork maintainers (you!) + original [contributors]
 [contributors]: https://github.com/thoughtbot/laptop/graphs/contributors

--- a/laptop
+++ b/laptop
@@ -1,0 +1,77 @@
+#!/bin/sh
+
+install_pdftk_script() {
+    fancy_echo "Installing Pdftk ..."
+    curl -o ~/Downloads/pdftk_download.pkg https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/pdftk_server-2.02-mac_osx-10.11-setup.pkg
+
+    pkgutil --expand ~/Downloads/pdftk_download.pkg ~/Downloads/pdftk_package
+
+    cd ~ && mkdir /usr/local/Cellar/pdftk /usr/local/Cellar/pdftk/2.02 /usr/local/Cellar/pdftk/2.02/bin /usr/local/Cellar/pdftk/2.02/lib /usr/local/Cellar/pdftk/2.02/share /usr/local/Cellar/pdftk/2.02/share/man /usr/local/Cellar/pdftk/2.02/share/man/man1
+
+    mv ~/Downloads/pdftk_package/pdftk.pkg/Payload ~/Downloads/pdftk_package/pdftk.pkg/payload.gz
+
+    gunzip ~/Downloads/pdftk_package/pdftk.pkg/payload.gz
+
+    cd ~/Downloads/pdftk_package/pdftk.pkg/ && cpio -iv < ~/Downloads/pdftk_package/pdftk.pkg/payload && cd ~
+
+    cd ~ && mv Downloads/pdftk_package/pdftk.pkg/bin/pdftk /usr/local/Cellar/pdftk/2.02/bin/pdftk && mv Downloads/pdftk_package/pdftk.pkg/lib/* /usr/local/Cellar/pdftk/2.02/lib/ && mv Downloads/pdftk_package/pdftk.pkg/man/pdftk.1 /usr/local/Cellar/pdftk/2.02/share/man/man1/pdftk.1
+
+    brew link pdftk
+}
+
+install_dotfiles_script() {
+    fancy_echo "Setting up itermocil, Oh My Zsh and dot-files"
+
+    cd ~ && git clone git@github.com:sprk/spark-tools.git
+    mv ~/spark-tools/dot-files ~/.files
+
+    ln -nsf ~/.files/itermocil ~/.itermocil
+    ln -nsf ~/.files/zshrc/.zshrc ~/.zshrc
+    ln -nsf ~/.files/zshrc/.zshenv ~/.zshenv
+    ln -nsf ~/.files/git/gitconfig ~/.gitconfig
+
+    fancy_echo "Finished setting up your command line interface"
+}
+
+append_to_file "$HOME/.gemrc" 'gem: --no-document'
+
+# Spark recommended stuff
+brew cask install brave-browser
+brew cask install dashlane
+brew cask install firefox
+brew cask install iterm2
+brew cask install postman
+brew cask install psequel
+brew cask install slack
+brew cask install visual-studio-code
+brew install TomAnthony/brews/itermocil
+sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
+
+fancy_echo "Installing Bundler and setting cores..."
+sudo gem install bundler
+
+fancy_echo "Configuring Bundler ..."
+number_of_cores=$(sysctl -n hw.ncpu)
+bundle config --global jobs $((number_of_cores - 1))
+
+install_pdftk_script
+install_dotfiles_script
+
+brew cleanup
+brew doctor
+
+# fancy_echo "Ruby Setup"
+# TODO - Use scripting magic to:
+# 1. Enable setup of rbenv ruby install without the need of restarting the terminal.
+# 2. Grab official version from https://github.com/sprk/spark/blob/master/.ruby-version
+
+# fancy_echo "Installing Spark Ruby"
+# rbenv install 2.6.5
+# rbenv global 2.6.5
+# rbenv rehash
+# gem install bundler
+# gem install rails
+
+# fancy_echo '...Finished Ruby installation checks.'
+
+fancy_echo 'All done!'

--- a/mac
+++ b/mac
@@ -107,24 +107,19 @@ if brew list | grep -Fq brew-cask; then
   brew uninstall --force brew-cask
 fi
 
-fancy_echo "Updating Homebrew formulae ..."
+fancy_echo "Updating Homebrew ..."
 brew update --force # https://github.com/Homebrew/brew/issues/1151
 brew bundle --file=- <<EOF
-tap "caskroom/cask"
-tap "d12frosted/emacs-plus"
-tap "homebrew/services"
 tap "thoughtbot/formulae"
+tap "homebrew/services"
 tap "universal-ctags/universal-ctags"
 
 # Unix
 brew "git"
-brew "neovim"
 brew "openssl"
-brew "parity"
 brew "rcm"
 brew "reattach-to-user-namespace"
 brew "ripgrep"
-brew "the_silver_searcher"
 brew "tmux"
 brew "universal-ctags", args: ["HEAD"]
 brew "vim"
@@ -141,30 +136,20 @@ brew "imagemagick"
 brew "libyaml" # should come after openssl
 brew "coreutils"
 brew "yarn"
-
-# Spark recommended stuff
-brew "google-chrome"
-brew "dashlane"
-brew "postman"
-brew "iterm2"
-brew "psequel"
-brew "slack"
+brew "rbenv"
+brew "ruby-build"
 
 # Databases
 brew "postgres", restart_service: :changed
 brew "redis", restart_service: :changed
-brew "rbenv"
-brew "ruby-build"
-brew "nodejs"
 EOF
 
+if [ -f "$HOME/laptop/laptop" ]; then
+  cp ~/laptop/laptop ~/.laptop.local
+fi
 
-# Ruby stuff
-
-# TODO - use scripting magic to grab official version from https://github.com/sprk/spark/blob/master/.ruby-version
-rbenv install 2.4.5
-rbenv rehash
-gem update --system
-gem i bundler
-number_of_cores=$(sysctl -n hw.ncpu)
-bundle config --global jobs $((number_of_cores - 1))
+if [ -f "$HOME/.laptop.local" ]; then
+  fancy_echo "Running your customizations from ~/.laptop.local ..."
+  # shellcheck disable=SC1090
+  . "$HOME/.laptop.local"
+fi


### PR DESCRIPTION
## Description:
Update the present laptop script to be compatible with Mac OS Catalina. Update the applications installed via the script and creates a laptop file which can be used in the future to easily expand the capabilities of this install script. 

This is **[dependant on the dotfiles PR](https://github.com/sprk/spark-tools/pull/2)** getting merged as it pulls from that repository to automatically setup those dotfiles.
1. The $PATH is invoked within the .zshenv as export PATH="$HOME/.rbenv/bin:$PATH" then sourced in the .zshrc
2. This was needed to ensure rbenv was invoked in all instances of the shell  [(Catalina issue)](https://programmingzen.com/installing-rbenv-on-zsh-on-macos/).

I wasn't able to get this to successfully install the rbenv ruby version without breaking the script. Instructions for how to do that, after the script is run, is listed in the README.md.